### PR TITLE
support react-native

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var htmlparser = require("htmlparser2")
+var htmlparser = require('htmlparser2-without-node-native')
 var converters = require('./converters/')
 
 var escapeMap = {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "ISC",
   "dependencies": {
     "commander": "^2.9.0",
-    "htmlparser2": "^3.9.0",
+    "htmlparser2-without-node-native": "^3.9.0",
     "request": "^2.67.0"
   },
   "devDependencies": {


### PR DESCRIPTION
benchmark lib: https://github.com/AndreasMadsen/htmlparser-benchmark

for `htmlparser2-without-node-native`:

```
7.46853 ms/file ± 5.47285
```

for `htmlparser2`:

```
5.37445 ms/file ± 4.75978
```

好像差别并不大