### PR TITLE
Add <b> and <i> as supported HTML tags

### DIFF
--- a/converters/commonmark.js
+++ b/converters/commonmark.js
@@ -5,9 +5,19 @@
 var LI_HEADER = 'H2M_LI_HEADER'
 
 module.exports = {
+  i: function (node) {
+    if (node.md) {
+      return `*${node.md}*`
+    }
+  },
   em: function (node) {
     if (node.md) {
       return `*${node.md}*`
+    }
+  },
+  b: function (node) {
+    if (node.md) {
+      return `**${node.md}**`
     }
   },
   strong: function (node) {


### PR DESCRIPTION
This PR adds `<i>` and `<b>` as supported tags, and fixes #16 .
https://github.com/nandenjin/h2m/commit/5bbfccf4fc0e47cd0dc93a14970950092ba23ab5#commitcomment-116517640
